### PR TITLE
Improve SegWit IBD question

### DIFF
--- a/segwit/README.md
+++ b/segwit/README.md
@@ -28,7 +28,7 @@
 1. What was the quadratic sighash problem prior to Segwit? How does [BIP 143](https://github.com/bitcoin/bips/blob/master/bip-0143.mediawiki) solve this? (SegWit's Impact on Scalability/SegWit Benefits)
 1. What is weight versus virtual bytes? How do they differ? How does weight change the relative costs of inputs and outputs? (Advanced SegWit)
 1. What rationale was used to decide on the 4 MB SegWit block weight (3 x old_tx_bytes + segwit_tx_bytes), instead of say a 2 MB block weight (old_tx_bytes + segwit_tx_bytes)? (SegWit's Impact on Scalability/Advanced SegWit)
-1. How does a virtual block increase affect IBD cost over time? (Advanced SegWit)
+1. How does a virtual block increase affect IBD cost over time? (Advanced SegWit/SegWit Costs)
 1. What is ASIC BOOST and what did it have to do with SegWit's deployment? (Gregory Maxwell’s Inhibition Proposal)
 1. How could BIP 9 be considered controversial within the community? How was BIP 148 received when first proposed? (Advanced SegWit)
 1. How did users know whether miners support SegWit prior to activation? (The Long Road to SegWit)

--- a/segwit/README.md
+++ b/segwit/README.md
@@ -28,7 +28,7 @@
 1. What was the quadratic sighash problem prior to Segwit? How does [BIP 143](https://github.com/bitcoin/bips/blob/master/bip-0143.mediawiki) solve this? (SegWit's Impact on Scalability/SegWit Benefits)
 1. What is weight versus virtual bytes? How do they differ? How does weight change the relative costs of inputs and outputs? (Advanced SegWit)
 1. What rationale was used to decide on the 4 MB SegWit block weight (3 x old_tx_bytes + segwit_tx_bytes), instead of say a 2 MB block weight (old_tx_bytes + segwit_tx_bytes)? (SegWit's Impact on Scalability/Advanced SegWit)
-1. How does a virtual block increase affect IBD cost over time? (Advanced SegWit/SegWit Costs)
+1. How does SegWit affect initial block download (IBD)? (Advanced SegWit/SegWit Costs)
 1. What is ASIC BOOST and what did it have to do with SegWit's deployment? (Gregory Maxwell’s Inhibition Proposal)
 1. How could BIP 9 be considered controversial within the community? How was BIP 148 received when first proposed? (Advanced SegWit)
 1. How did users know whether miners support SegWit prior to activation? (The Long Road to SegWit)


### PR DESCRIPTION
1. "How does a virtual block increase affect IBD cost over time?" is not answered in the "Advanced SegWit" video/slides/transcript fully. Added the "SegWit Costs" with answers:
- https://bitcoincore.org/en/2016/10/28/segwit-costs/#block-validation-costs
- https://bitcoincore.org/en/2016/10/28/segwit-costs/#risks-due-to-larger-blocks

2. There are no such thing like a "virtual block" (see https://github.com/bitcoin/bips/blob/master/bip-0141.mediawiki#Block_size).
Also BIP-141 _increases_ nothing, instead the "block size" consensus parameter was replaced with the "block weight". For reference:
- https://github.com/bitcoin/bitcoin/commit/2b1f6f9ccf36f1e0a2c9d99154e1642f796d7c2b
- https://github.com/bitcoin/bitcoin/commit/3babbcb48786372d4b22171674c4cc5a6220c294
The suggested change removes any ambiguity from the question though with a price of being a bit wider.